### PR TITLE
Derive Eq and PartialEq on MerkleProof.

### DIFF
--- a/src/algorithms/sha256.rs
+++ b/src/algorithms/sha256.rs
@@ -28,7 +28,7 @@ use sha2::{digest::FixedOutput, Digest, Sha256};
 /// ```
 ///
 /// [`Hasher`]: crate::Hasher
-#[derive(Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Sha256Algorithm {}
 
 impl Hasher for Sha256Algorithm {

--- a/src/merkle_proof.rs
+++ b/src/merkle_proof.rs
@@ -46,6 +46,7 @@ use core::convert::TryFrom;
 ///
 /// [`Hasher`]: crate::Hasher
 /// [`algorithms::Sha256`]: crate::algorithms::Sha256
+#[derive(Debug, Eq, PartialEq)]
 pub struct MerkleProof<T: Hasher> {
     proof_hashes: Vec<T::Hash>,
 }


### PR DESCRIPTION
Thanks for the library, it's working really well for me so far 👍 

I have a use case where I am using axum and it's `TypedHeader` struct and I want to decode a header to a struct that includes a `MerkleProof::<Sha256>` but I can't as it does not implement `Eq` or `PartialEq`. I would be able to workaround this by storing a `Vec<u8>` and lazily decoding to `MerkleProof` elsewhere in the code but that is awkward.

This small change derives `Debug`, `Eq` and `PartialEq` for `MerkleProof`. All tests continue to pass.