### PR TITLE
Removing dependency on micromath. computing height with integers only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = ["/ci/*", "/scripts/*", "/.github/*", "/bors.toml"]
 
 [dependencies]
 sha2 = { version = "0.10.2", default-features = false }
-micromath = "2.0.0"
 
 # standard crate data is left out
 [dev-dependencies]

--- a/src/utils/indices.rs
+++ b/src/utils/indices.rs
@@ -35,8 +35,13 @@ pub fn tree_depth(leaves_count: usize) -> usize {
     if leaves_count == 1 {
         1
     } else {
-        let val = micromath::F32(leaves_count as f32);
-        val.log2().ceil().0 as usize
+        let mut current: usize = leaves_count;
+        let mut level = 0;
+        while current > 0 {
+            level = level + 1;
+            current = current >> 2;
+        }
+        level
     }
 }
 

--- a/src/utils/indices.rs
+++ b/src/utils/indices.rs
@@ -32,17 +32,13 @@ pub fn parent_indices(indices: &[usize]) -> Vec<usize> {
 }
 
 pub fn tree_depth(leaves_count: usize) -> usize {
-    if leaves_count == 1 {
-        1
-    } else {
-        let mut current: usize = leaves_count;
-        let mut level = 0;
-        while current > 0 {
-            level = level + 1;
-            current = current >> 2;
-        }
-        level
+    let mut current: usize = leaves_count;
+    let mut level = 0;
+    while current > 0 {
+        level = level + 1;
+        current = current >> 1;
     }
+    level
 }
 
 pub fn uneven_layers(tree_leaves_count: usize) -> BTreeMap<usize, usize> {


### PR DESCRIPTION
This reduces the overall dependency tree, which was only being used in computing the tree height.
It may also be benefitial in some environments (e.g.: zk) to be able to use integer math only