### PR TITLE
Remove dependency on micromath, compute height with integers only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = ["/ci/*", "/scripts/*", "/.github/*", "/bors.toml"]
 
 [dependencies]
 sha2 = { version = "0.10", default-features = false }
-micromath = "2.0.0"
 
 # standard crate data is left out
 [dev-dependencies]

--- a/src/utils/indices.rs
+++ b/src/utils/indices.rs
@@ -32,12 +32,7 @@ pub fn parent_indices(indices: &[usize]) -> Vec<usize> {
 }
 
 pub fn tree_depth(leaves_count: usize) -> usize {
-    if leaves_count == 1 {
-        1
-    } else {
-        let val = micromath::F32(leaves_count as f32);
-        val.log2().ceil().0 as usize
-    }
+    8 * core::mem::size_of::<usize>() - leaves_count.leading_zeros() as usize
 }
 
 pub fn uneven_layers(tree_leaves_count: usize) -> BTreeMap<usize, usize> {


### PR DESCRIPTION
This reduces the overall dependency tree, which was only being used in computing the tree height.
It may also be benefitial in some environments (e.g.: zk) to be able to use integer math only.

The snippet `leaves_count as f32` caused some trouble.  Let's remove it.

(Description stolen from https://github.com/antouhou/rs-merkle/pull/16 because it's honestly much better than what I had originally typed up.)