### PR TITLE
Enforce no_std support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,18 @@ jobs:
         override: true
     - name: Run tests
       run: cargo test
+  no_std_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build without std
+        run: cargo build --no-default-features
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We tell github to build PRs with `--no-default-features` to ensure that building we no_std works.

This implements a suggestion brought up in the discussion around https://github.com/antouhou/rs-merkle/issues/19 and https://github.com/antouhou/rs-merkle/pull/18

Please review carefully: I tested the build command, but I couldn't locally test the full github workflow around it.