### PR TITLE
feat: add a hard check for no-std targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,9 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+          target: thumbv7em-none-eabi
       - name: Build without std
-        run: cargo build --no-default-features
+        run: cargo build --no-default-features --target thumbv7em-none-eabi
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request adds a check that it is possible to build the library for no-std targets, such as `thumbv7em-none-eabi`