### PR TITLE
feat: Support sha384 hash function

### DIFF
--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -2,5 +2,7 @@
 //!
 //! [`Hasher`]: crate::Hasher
 mod sha256;
+mod sha384;
 
 pub use sha256::Sha256Algorithm as Sha256;
+pub use sha384::Sha384Algorithm as Sha384;

--- a/src/algorithms/sha384.rs
+++ b/src/algorithms/sha384.rs
@@ -5,7 +5,6 @@
 use crate::{prelude::*, Hasher};
 use sha2::{digest::FixedOutput, Digest, Sha384};
 
-
 /// Sha384 implementation of the [`Hasher`] trait.
 ///
 /// # Examples

--- a/src/algorithms/sha384.rs
+++ b/src/algorithms/sha384.rs
@@ -1,0 +1,47 @@
+//
+// sha384.rs
+// Author imotai <codego.me@gmail.com>
+//
+use crate::{prelude::*, Hasher};
+use sha2::{digest::FixedOutput, Digest, Sha384};
+
+
+/// Sha384 implementation of the [`Hasher`] trait.
+///
+/// # Examples
+///
+/// ```
+/// # use rs_merkle::{MerkleTree, MerkleProof, algorithms::Sha384, Hasher, Error, utils};
+/// # use std::convert::TryFrom;
+/// #
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+///  let tree = MerkleTree::<Sha384>::new();
+///  let other_tree: MerkleTree<Sha384> = MerkleTree::new();
+///
+/// let proof_bytes: Vec<u8> = vec![
+///     46, 125, 44, 3, 169, 80, 122, 226, 101, 236, 245, 181, 53, 104, 133, 165, 51, 147, 162,
+///     2, 157, 36, 19, 148, 153, 114, 101, 161, 162, 90, 239, 198, 37, 47, 16, 200, 54, 16,
+///     235, 202, 26, 5, 156, 11, 174, 130, 85, 235, 162, 249, 91, 228, 209, 215, 188, 250,
+///     137, 215, 36, 138, 130, 217, 241, 17, 229, 160, 31, 238, 20, 224, 237, 92, 72, 113, 79,
+///     34, 24, 15, 37, 173, 131, 101, 181, 63, 151, 121, 247, 157, 196, 163, 215, 233, 57, 99,
+///     249, 74,
+/// ];
+///
+/// let proof_result = MerkleProof::<Sha384>::from_bytes(&proof_bytes);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`Hasher`]: crate::Hasher
+#[derive(Clone)]
+pub struct Sha384Algorithm {}
+
+impl Hasher for Sha384Algorithm {
+    type Hash = [u8; 48];
+
+    fn hash(data: &[u8]) -> [u8; 48] {
+        let mut hasher = Sha384::new();
+        hasher.update(data);
+        <[u8; 48]>::from(hasher.finalize_fixed())
+    }
+}

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -61,10 +61,8 @@ impl<T: Hasher> MerkleTree<T> {
     /// # }
     pub fn from_leaves(leaves: &[T::Hash]) -> Self {
         let mut tree = Self::new();
-
         tree.append(leaves.to_vec().as_mut());
         tree.commit();
-
         tree
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,10 +1,19 @@
 use rayon::prelude::*;
-use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
+use rs_merkle::{
+    algorithms::{Sha256, Sha384},
+    Hasher, MerkleTree,
+};
 
 pub struct TestData {
     pub leaf_values: Vec<String>,
     pub expected_root_hex: String,
     pub leaf_hashes: Vec<[u8; 32]>,
+}
+
+pub struct TestData48 {
+    pub leaf_values: Vec<String>,
+    pub expected_root_hex: String,
+    pub leaf_hashes: Vec<[u8; 48]>,
 }
 
 fn combine<T: Clone>(active: Vec<T>, rest: Vec<T>, mut combinations: Vec<Vec<T>>) -> Vec<Vec<T>> {
@@ -40,8 +49,21 @@ pub fn setup() -> TestData {
         .iter()
         .map(|x| Sha256::hash(x.as_bytes()))
         .collect();
-
     TestData {
+        leaf_values: leaf_values.iter().cloned().map(String::from).collect(),
+        leaf_hashes,
+        expected_root_hex: String::from(expected_root_hex),
+    }
+}
+
+pub fn setup_sha384() -> TestData48 {
+    let leaf_values = ["a", "b", "c", "d", "e", "f"];
+    let expected_root_hex = "19090f8e9527d4baaddbc1b9bb1142d96ef337537cfdb4aa176a709036be05fca58412b65c630d757288aaa7d54a57ad";
+    let leaf_hashes = leaf_values
+        .iter()
+        .map(|x| Sha384::hash(x.as_bytes()))
+        .collect();
+    TestData48 {
         leaf_values: leaf_values.iter().cloned().map(String::from).collect(),
         leaf_hashes,
         expected_root_hex: String::from(expected_root_hex),

--- a/tests/merkle_tree_test.rs
+++ b/tests/merkle_tree_test.rs
@@ -2,14 +2,25 @@ mod common;
 
 pub mod root {
     use crate::common;
-    use rs_merkle::{algorithms::Sha256, MerkleTree};
+    use rs_merkle::{
+        algorithms::{Sha256, Sha384},
+        MerkleTree,
+    };
 
     #[test]
     pub fn should_return_a_correct_root() {
         let test_data = common::setup();
-
         let merkle_tree = MerkleTree::<Sha256>::from_leaves(&test_data.leaf_hashes);
+        assert_eq!(
+            merkle_tree.root_hex(),
+            Some(test_data.expected_root_hex.to_string())
+        );
+    }
 
+    #[test]
+    pub fn should_return_a_correct_root_sha384() {
+        let test_data = common::setup_sha384();
+        let merkle_tree = MerkleTree::<Sha384>::from_leaves(&test_data.leaf_hashes);
         assert_eq!(
             merkle_tree.root_hex(),
             Some(test_data.expected_root_hex.to_string())


### PR DESCRIPTION
Hi, I am working on the Arweave rust SDK which needs sha384 to generate the Merkle root but the rs-merkle supports sha256 only. This PR will support sha384 and  comments are welcome