### PR TITLE
feat: shoten hash function implementations

### DIFF
--- a/src/algorithms/sha256.rs
+++ b/src/algorithms/sha256.rs
@@ -35,9 +35,28 @@ impl Hasher for Sha256Algorithm {
     type Hash = [u8; 32];
 
     fn hash(data: &[u8]) -> [u8; 32] {
-        let mut hasher = Sha256::new();
+        <[u8; 32]>::from(Sha256::digest(data))
+    }
+}
 
-        hasher.update(data);
-        <[u8; 32]>::from(hasher.finalize_fixed())
+
+#[cfg(test)]
+mod test {
+    use crate::{prelude::*, Hasher};
+    use super::Sha256Algorithm;
+    
+    use sha2::{Digest, Sha256, digest::FixedOutput};
+
+    #[test]
+    fn test_sha256_with_regular_digest() {
+        let buffer = b"hello world";
+        
+        let output = Sha256Algorithm::hash(&buffer[..]);
+
+        let mut old_method = Sha256::new();
+        old_method.update(&buffer);
+        
+        let expected = <[u8; 32]>::from(old_method.finalize_fixed())
+        assert_eq!(output, expected)
     }
 }

--- a/src/algorithms/sha384.rs
+++ b/src/algorithms/sha384.rs
@@ -3,7 +3,7 @@
 // Author imotai <codego.me@gmail.com>
 //
 use crate::{prelude::*, Hasher};
-use sha2::{digest::FixedOutput, Digest, Sha384};
+use sha2::{Digest, Sha384};
 
 /// Sha384 implementation of the [`Hasher`] trait.
 ///
@@ -39,8 +39,27 @@ impl Hasher for Sha384Algorithm {
     type Hash = [u8; 48];
 
     fn hash(data: &[u8]) -> [u8; 48] {
-        let mut hasher = Sha384::new();
-        hasher.update(data);
-        <[u8; 48]>::from(hasher.finalize_fixed())
+        <[u8; 48]>::from(Sha384::digest(data))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Sha384Algorithm;
+    use crate::{prelude::*, Hasher};
+
+    use sha2::{digest::FixedOutput, Digest, Sha384};
+
+    #[test]
+    fn test_sha384_with_regular_digest() {
+        let buffer = b"hello world";
+
+        let output = Sha384Algorithm::hash(&buffer[..]);
+
+        let mut old_method = Sha384::new();
+        old_method.update(&buffer);
+
+        let expected = <[u8; 48]>::from(old_method.finalize_fixed());
+        assert_eq!(output, expected)
     }
 }


### PR DESCRIPTION
### Summary
When importing the trait ``sha2::Digest``, you have access to the digest function, which both shortens the code into one line and does not require a mutable instantiation. :)


### Gist Changes

```diff
fn hash(data: &[u8]) -> [u8; 32] {
-          let mut hasher = Sha256::new();
-          hasher.update(data);
-         <[u8; 32]>::from(hasher.finalize_fixed())
+         <[u8; 32]>::from(Sha256::digest(data))
}
```

```diff
fn hash(data: &[u8]) -> [u8; 48] {
-          let mut hasher = Sha384::new();
-          hasher.update(data);
-         <[u8; 48]>::from(hasher.finalize_fixed())
+         <[u8; 48]>::from(Sha384::digest(data))
}
```

I also added tests below my commits to show that operations are equivalent.