### PR TITLE
feat: get node at layer and proof to node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"], optional=true }
 # standard crate data is left out
 [dev-dependencies]
 rayon = "1.5.1"
+hex = "0.4"
 
 [features]
 default = ['std']

--- a/examples/leaf_proof.rs
+++ b/examples/leaf_proof.rs
@@ -1,0 +1,38 @@
+// Minimal example: Prove leaf belongs to tree root
+//
+// Tree structure (4 leaves):
+//
+//           ROOT
+//          /    \
+//        N1      N2
+//       /  \    /  \
+//      a    b  c    d
+//              ↑
+//           Proving this leaf belongs to ROOT
+//
+// Proof contains sibling hashes along the path from c → ROOT
+// Path: c → N2 → ROOT
+// Siblings needed: [b, N1]
+
+use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
+
+fn main() {
+    // Build tree
+    let leaves: Vec<[u8; 32]> = ["a", "b", "c", "d"]
+        .iter()
+        .map(|x| Sha256::hash(x.as_bytes()))
+        .collect();
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let root = tree.root().unwrap();
+    println!("Root: {:?}", root);
+
+    // Create proof for leaf at index 2 (leaf "c")
+    let leaf_index = 2;
+    let proof = tree.proof(&[leaf_index]);
+
+    // Verify
+    let is_valid = proof.verify(root, &[leaf_index], &[leaves[leaf_index]], leaves.len());
+
+    assert!(is_valid);
+    println!("✓ Leaf → Root proof verified successfully!");
+}

--- a/examples/node_proof.rs
+++ b/examples/node_proof.rs
@@ -1,0 +1,49 @@
+// Prove intermediate node belongs to tree root
+//
+// Tree structure (16 leaves):
+//
+// Level 5:                    ROOT
+//                            /    \
+// Level 4:                 N4      N4'
+//                         /  \    /   \
+// Level 3:              N3   N3' N3'' N3'''
+//                      / \   / \
+// Level 2:           N0  N1 N2  N3  ...  ← Intermediate nodes
+//                   /  \
+// Level 1:        N10 N11 ...
+//                / \  / \
+// Level 0:      L0 L1 L2 L3 L4 ... L15    ← Leaves
+//               ↑
+//            Proving N0 (intermediate node) belongs to ROOT
+//
+// Proof path: N0 → N3 → N4 → ROOT
+// Siblings needed: [N1, N3', N4']
+//
+// Key insight: We treat N0, N1, N2, N3 as "leaves" of a smaller tree
+// Then verify using standard MerkleProof::verify()!
+
+use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
+
+fn main() {
+    // Build tree
+    let leaves: Vec<[u8; 32]> = (0..16)
+        .map(|i| Sha256::hash(format!("leaf_{}", i).as_bytes()))
+        .collect();
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let root = tree.root().unwrap();
+
+    // Get intermediate node at level 2
+    let level = 2;
+    let nodes = tree.get_nodes_at_level(level).unwrap();
+    let (node_index, node_hash) = nodes[0];
+
+    // Create proof (returns MerkleProof!)
+    let proof = tree.proof_from_node(level, node_index).unwrap();
+
+    // Verify (treat nodes at this level as "leaves")
+    let relative_index = 0; // First node at this level
+    let is_valid = proof.verify(root, &[relative_index], &[node_hash], nodes.len());
+
+    assert!(is_valid);
+    println!("✓ Node → Root proof verified successfully!");
+}


### PR DESCRIPTION
Hi @antouhou — we have a specific requirement at @maidsafe for accessing intermediate nodes and generating proofs from them. This PR introduces public API methods to retrieve tree nodes at arbitrary levels and to create proofs from intermediate nodes up to the root. We’d appreciate it if you could review the PR and consider adding this feature.

## New Methods

**`MerkleTree::get_nodes_at_level(level: usize) -> Option<Vec<(usize, Hash)>>`**
- Returns all nodes at a specific tree level
- Level 0 = leaves, depth = root
- Returns `None` for invalid levels

**`MerkleTree::proof_from_node(level: usize, node_index: usize) -> Option<MerkleProof<T>>`**
- Creates a Merkle proof from any node to the root
- Returns `MerkleProof` that works with standard `verify()` method
- Enables compact proofs for intermediate nodes without full tree traversal

## Use Cases

- Batch payment routing with hierarchical proofs
- Multi-stage verification systems
- Proof size optimization (prove to intermediate node instead of leaf)
- Tree structure analysis and debugging

## Testing

- Added 6 tests for `get_nodes_at_level()`
- Added 4 tests for `proof_from_node()`
- All existing tests pass
- Added examples: `leaf_proof.rs` and `node_proof.rs`

---

**Lines changed:** 400 LOC (implementation + tests + examples)
**Breaking changes:** None
