### PR TITLE
chore: change name of forked crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"], optional=true }
 # standard crate data is left out
 [dev-dependencies]
 rayon = "1.5.1"
+hex = "0.4"
 
 [features]
 default = ['std']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "rs_merkle"
-version = "1.5.0"
+name = "ant-merkle"
+version = "1.5.1"
 authors = ["Anton Suprunchuk <anton.suprunchuk@gmail.com>"]
-description = "The most advanced Merkle Tree library for Rust. Supports creating and verifying proofs, multi-proofs, as well as advanced features, such as tree diffs, transactional changes, and rollbacks"
+description = "The most advanced Merkle Tree library for Rust. Supports creating and verifying proofs, multi-proofs, as well as advanced features, such as tree diffs, transactional changes, and rollbacks. Forked for use with the Autonomi network."
 edition = "2018"
 license = "Apache-2.0/MIT"
-repository = "https://github.com/antouhou/rs-merkle"
+repository = "https://github.com/maidsafe/ant-merkle"
 documentation = "https://docs.rs/rs_merkle/"
 readme = "README.md"
 keywords = ["merkle", "tree", "proof", "hash", "multiproof",]

--- a/examples/leaf_proof.rs
+++ b/examples/leaf_proof.rs
@@ -1,0 +1,38 @@
+// Minimal example: Prove leaf belongs to tree root
+//
+// Tree structure (4 leaves):
+//
+//           ROOT
+//          /    \
+//        N1      N2
+//       /  \    /  \
+//      a    b  c    d
+//              ↑
+//           Proving this leaf belongs to ROOT
+//
+// Proof contains sibling hashes along the path from c → ROOT
+// Path: c → N2 → ROOT
+// Siblings needed: [b, N1]
+
+use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
+
+fn main() {
+    // Build tree
+    let leaves: Vec<[u8; 32]> = ["a", "b", "c", "d"]
+        .iter()
+        .map(|x| Sha256::hash(x.as_bytes()))
+        .collect();
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let root = tree.root().unwrap();
+    println!("Root: {:?}", root);
+
+    // Create proof for leaf at index 2 (leaf "c")
+    let leaf_index = 2;
+    let proof = tree.proof(&[leaf_index]);
+
+    // Verify
+    let is_valid = proof.verify(root, &[leaf_index], &[leaves[leaf_index]], leaves.len());
+
+    assert!(is_valid);
+    println!("✓ Leaf → Root proof verified successfully!");
+}

--- a/examples/node_proof.rs
+++ b/examples/node_proof.rs
@@ -1,0 +1,49 @@
+// Prove intermediate node belongs to tree root
+//
+// Tree structure (16 leaves):
+//
+// Level 5:                    ROOT
+//                            /    \
+// Level 4:                 N4      N4'
+//                         /  \    /   \
+// Level 3:              N3   N3' N3'' N3'''
+//                      / \   / \
+// Level 2:           N0  N1 N2  N3  ...  ← Intermediate nodes
+//                   /  \
+// Level 1:        N10 N11 ...
+//                / \  / \
+// Level 0:      L0 L1 L2 L3 L4 ... L15    ← Leaves
+//               ↑
+//            Proving N0 (intermediate node) belongs to ROOT
+//
+// Proof path: N0 → N3 → N4 → ROOT
+// Siblings needed: [N1, N3', N4']
+//
+// Key insight: We treat N0, N1, N2, N3 as "leaves" of a smaller tree
+// Then verify using standard MerkleProof::verify()!
+
+use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
+
+fn main() {
+    // Build tree
+    let leaves: Vec<[u8; 32]> = (0..16)
+        .map(|i| Sha256::hash(format!("leaf_{}", i).as_bytes()))
+        .collect();
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let root = tree.root().unwrap();
+
+    // Get intermediate node at level 2
+    let level = 2;
+    let nodes = tree.get_nodes_at_level(level).unwrap();
+    let (node_index, node_hash) = nodes[0];
+
+    // Create proof (returns MerkleProof!)
+    let proof = tree.proof_from_node(level, node_index).unwrap();
+
+    // Verify (treat nodes at this level as "leaves")
+    let relative_index = 0; // First node at this level
+    let is_valid = proof.verify(root, &[relative_index], &[node_hash], nodes.len());
+
+    assert!(is_valid);
+    println!("✓ Node → Root proof verified successfully!");
+}


### PR DESCRIPTION
We will use `ant-merkle` to keep it distinct from the main crate.

It looks like this is also including a commit from a previous PR to this fork. For now all I can do is just assume this is OK.