### PR TITLE
Make sha2 optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_merkle"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Anton Suprunchuk <anton.suprunchuk@gmail.com>"]
 description = "The most advanced Merkle Tree library for Rust. Supports creating and verifying proofs, multi-proofs, as well as advanced features, such as tree diffs, transactional changes, and rollbacks"
 edition = "2018"
@@ -8,20 +8,21 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/antouhou/rs-merkle"
 documentation = "https://docs.rs/rs_merkle/"
 readme = "README.md"
-keywords = ["merkle", "tree", "proof", "hash", "multiproof",]
+keywords = ["merkle", "tree", "proof", "hash", "multiproof", ]
 exclude = ["/ci/*", "/scripts/*", "/.github/*", "/bors.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sha2 = { version = "0.10", default-features = false }
-tiny-keccak = { version = "2.0", features = ["keccak"], optional=true }
+sha2 = { version = "0.10", default-features = false, optional = true }
+tiny-keccak = { version = "2.0", features = ["keccak"], optional = true }
 
 # standard crate data is left out
 [dev-dependencies]
 rayon = "1.5.1"
 
 [features]
-default = ['std']
-std = ["sha2/std"]
+default = ['std', "sha2"]
+sha2 = ["dep:sha2"]
+std = ["dep:sha2", "sha2/std"]
 keccak256 = ["dep:tiny-keccak"]

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,13 +1,17 @@
 //! This module contains built-in implementations of the [`Hasher`]
 //!
 //! [`Hasher`]: crate::Hasher
+#[cfg(feature = "sha2")]
 mod sha256;
+#[cfg(feature = "sha2")]
 mod sha384;
 
 #[cfg(feature = "keccak256")]
 mod keccak256;
 
+#[cfg(feature = "sha2")]
 pub use sha256::Sha256Algorithm as Sha256;
+#[cfg(feature = "sha2")]
 pub use sha384::Sha384Algorithm as Sha384;
 
 #[cfg(feature = "keccak256")]


### PR DESCRIPTION
Right now there's no way to opt out of the sha2 dependency, even if you are using a different hash.