### PR TITLE
critical vulnerability: reject duplicate leaf indices in proof verification

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ pub enum ErrorKind {
     HashConversionError,
     NotEnoughHashesToCalculateRoot,
     LeavesIndicesCountMismatch,
+    DuplicateLeafIndex,
+    LeafIndexOutOfBounds,
 }
 
 /// The error type for tree traversals/parsing errors of the [`MerkleProof`] and [`PartialTree`].
@@ -68,6 +70,23 @@ impl Error {
         Self::new(
             ErrorKind::NotEnoughHashesToCalculateRoot,
             "proof doesn't contain enough data to extract the root".to_string(),
+        )
+    }
+
+    pub fn leaf_index_out_of_bounds(total_leaves: usize) -> Self {
+        Self::new(
+            ErrorKind::LeafIndexOutOfBounds,
+            format!(
+                "leaf index is out of bounds, total leaves count is {}",
+                total_leaves
+            ),
+        )
+    }
+
+    pub fn duplicate_leaf_index() -> Self {
+        Self::new(
+            ErrorKind::DuplicateLeafIndex,
+            String::from("leaf indices contain duplicates"),
         )
     }
 

--- a/src/merkle_proof.rs
+++ b/src/merkle_proof.rs
@@ -211,6 +211,20 @@ impl<T: Hasher> MerkleProof<T> {
                 leaf_hashes.len(),
             ));
         }
+
+        // Reject indices that fall outside the leaf range.
+        if leaf_indices.iter().any(|&i| i >= total_leaves_count) {
+            return Err(Error::leaf_index_out_of_bounds(total_leaves_count));
+        }
+
+        // Check for duplicate indices to prevent a fake leaf from being
+        // silently ignored when it shares an index with a real one.
+        let mut seen = leaf_indices.to_vec();
+        seen.sort_unstable();
+        if seen.windows(2).any(|w| w[0] == w[1]) {
+            return Err(Error::duplicate_leaf_index());
+        }
+
         let tree_depth = utils::indices::tree_depth(total_leaves_count);
 
         // Zipping indices and hashes into a vector of (original_index_in_tree, leaf_hash)

--- a/tests/duplicate_index_test.rs
+++ b/tests/duplicate_index_test.rs
@@ -1,0 +1,79 @@
+use rs_merkle::{algorithms::Sha256, Hasher, MerkleProof, MerkleTree};
+
+#[test]
+fn duplicate_indices_should_not_verify() {
+    let leaves: Vec<[u8; 32]> = ["a", "b", "c", "d"]
+        .iter()
+        .map(|x| Sha256::hash(x.as_bytes()))
+        .collect();
+
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let root = tree.root().unwrap();
+
+    // Legitimate single-leaf proof for index 0
+    let proof = tree.proof(&[0]);
+    assert!(proof.verify(root, &[0], &[leaves[0]], leaves.len()));
+
+    // Duplicate index: same leaf claimed twice must be rejected
+    assert!(!proof.verify(root, &[0, 0], &[leaves[0], leaves[0]], leaves.len()));
+
+    // Duplicate index with a fake leaf smuggled after the real one.
+    // Before the fix, the real leaf's hash was used (stable sort) and the
+    // fake was silently ignored, causing verify() to return true.
+    let fake = Sha256::hash(b"FAKE");
+    let proof_01 = tree.proof(&[0, 1]);
+    assert!(proof_01.verify(root, &[0, 1], &[leaves[0], leaves[1]], leaves.len()));
+    assert!(!proof_01.verify(root, &[0, 1, 1], &[leaves[0], leaves[1], fake], leaves.len()));
+}
+
+#[test]
+fn out_of_bounds_indices_should_not_verify() {
+    let leaves: Vec<[u8; 32]> = ["a", "b", "c", "d"]
+        .iter()
+        .map(|x| Sha256::hash(x.as_bytes()))
+        .collect();
+
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let root = tree.root().unwrap();
+    let proof = tree.proof(&[0]);
+
+    let fake = Sha256::hash(b"FAKE");
+
+    // Index equal to total_leaves_count is out of bounds
+    assert!(!proof.verify(root, &[4], &[fake], leaves.len()));
+
+    // Large out-of-bounds index
+    assert!(!proof.verify(root, &[100], &[fake], leaves.len()));
+
+    // Proof extraction for valid index should still work
+    assert!(proof.verify(root, &[0], &[leaves[0]], leaves.len()));
+}
+
+#[test]
+fn root_returns_error_on_duplicate_indices() {
+    let leaves: Vec<[u8; 32]> = ["a", "b", "c"]
+        .iter()
+        .map(|x| Sha256::hash(x.as_bytes()))
+        .collect();
+
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let proof = tree.proof(&[0, 1]);
+
+    let result = proof.root(&[0, 0], &[leaves[0], leaves[0]], leaves.len());
+    assert!(result.is_err());
+}
+
+#[test]
+fn root_returns_error_on_out_of_bounds() {
+    let leaves: Vec<[u8; 32]> = ["a", "b", "c"]
+        .iter()
+        .map(|x| Sha256::hash(x.as_bytes()))
+        .collect();
+
+    let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+    let proof = tree.proof(&[0]);
+    let fake = Sha256::hash(b"FAKE");
+
+    let result = proof.root(&[3], &[fake], leaves.len());
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

- **Duplicate index vulnerability**: `MerkleProof::verify()` accepted duplicate leaf indices, allowing an attacker to smuggle a fake leaf alongside a real leaf at the same index. Due to stable sorting, the real leaf was used for tree reconstruction and the fake was silently ignored, causing `verify()` to return `true`.
- **Out-of-bounds indices**: Indices >= `total_leaves_count` were silently processed instead of being rejected. While not directly exploitable (requires hash preimage), this is a defense-in-depth fix.

Both checks are added to `MerkleProof::root()`, which is called by `verify()`.

## Reproduction

```rust
let leaves: Vec<[u8; 32]> = (0..4u8).map(|i| Sha256::hash(&[i])).collect();
let tree = MerkleTree::<Sha256>::from_leaves(&leaves);
let root = tree.root().unwrap();

let proof = tree.proof(&[0, 1]);
let fake = Sha256::hash(b"FAKE");

// Before fix: returns true (fake leaf accepted!)
// After fix: returns false
proof.verify(root, &[0, 1, 1], &[leaves[0], leaves[1], fake], leaves.len());